### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: otherosfs
 Priority: optional
 Homepage: https://sourceforge.net/projects/ccd2iso/
 Maintainer: Asheesh Laroia <asheesh@asheesh.org>
-Build-Depends: debhelper (>= 9), autotools-dev, dh-autoreconf
+Build-Depends: debhelper, autotools-dev, dh-autoreconf
 Standards-Version: 3.9.6
 Vcs-Git: https://github.com/paulproteus/ccd2iso-debian.git
 Vcs-Browser: https://github.com/paulproteus/ccd2iso-debian


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/ccd2iso/6d8d4b7b-745b-4aaf-88c4-48d6d559ee55.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/14/091c06d987b02fa0de984ca434b457f04ccfcf.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/aa/16d47512a024dadb40ea17f7913458f3cf6d8d.debug

No differences were encountered between the control files of package \*\*ccd2iso\*\*
### Control files of package ccd2iso-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-aa16d47512a024dadb40ea17f7913458f3cf6d8d-] {+14091c06d987b02fa0de984ca434b457f04ccfcf+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/6d8d4b7b-745b-4aaf-88c4-48d6d559ee55/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/6d8d4b7b-745b-4aaf-88c4-48d6d559ee55/diffoscope)).
